### PR TITLE
Possible fix for https://github.com/SShakusora/CreateEnhancedSchemati…

### DIFF
--- a/src/main/java/com/sshakusora/create_enhanced_schematicannon/network/packet/SyncBlockEntityDataPacket.java
+++ b/src/main/java/com/sshakusora/create_enhanced_schematicannon/network/packet/SyncBlockEntityDataPacket.java
@@ -3,6 +3,7 @@ package com.sshakusora.create_enhanced_schematicannon.network.packet;
 import com.sshakusora.create_enhanced_schematicannon.CES;
 import com.sshakusora.create_enhanced_schematicannon.sync.client.ClientSchematicHandler;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -15,7 +16,7 @@ public record SyncBlockEntityDataPacket(@Nullable CompoundTag data) implements C
     public static final StreamCodec<FriendlyByteBuf, SyncBlockEntityDataPacket> STREAM_CODEC =
             CustomPacketPayload.codec(
                     (pkt, buf) -> buf.writeNbt(pkt.data()),
-                    buf -> new SyncBlockEntityDataPacket(buf.readNbt())
+                    buf -> new SyncBlockEntityDataPacket((CompoundTag) buf.readNbt(NbtAccounter.unlimitedHeap()))
             );
 
     public static final IPayloadHandler<SyncBlockEntityDataPacket> HANDLE_REQUEST =


### PR DESCRIPTION
[…cannon/issues/17](https://github.com/SShakusora/CreateEnhancedSchematicannon/issues/17)

Neoforge at least should already split large NBT packets, but using the base `.readNbt()` function on the client runs into Minecraft's 10MB default limits. This should fix that. 